### PR TITLE
build: add missing release dep

### DIFF
--- a/esm-packages.json
+++ b/esm-packages.json
@@ -33,6 +33,7 @@
         "@sec-ant/readable-stream",
         "@semantic-release/commit-analyzer",
         "@semantic-release/error",
+        "@semantic-release/exec",
         "@semantic-release/github",
         "@semantic-release/npm",
         "@semantic-release/release-notes-generator",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
 		"typescript": "^5.0.0"
 	},
 	"dependencies": {
+		"@semantic-release/exec": "^7.0.3",
 		"commander": "^12.1.0",
 		"resolve-package-path": "^4.0.3"
 	},

--- a/yarn.lock
+++ b/yarn.lock
@@ -880,6 +880,7 @@ __metadata:
     "@rspack/cli": "npm:^1.1.6"
     "@rspack/core": "npm:^1.1.6"
     "@semantic-release/changelog": "npm:^6.0.3"
+    "@semantic-release/exec": "npm:^7.0.3"
     "@semantic-release/git": "npm:^10.0.1"
     "@swc/cli": "npm:^0.5.2"
     "@swc/core": "npm:^1.10.1"
@@ -2087,6 +2088,22 @@ __metadata:
   version: 4.0.0
   resolution: "@semantic-release/error@npm:4.0.0"
   checksum: 10/01213195ae3b8e2490b0d0db79525f7abbb1cc795494b46b8022f81ab1f24f5eab6232b549528b437cff872a66d36649f2fb4f3b56eba351d947a02cccc81ecc
+  languageName: node
+  linkType: hard
+
+"@semantic-release/exec@npm:^7.0.3":
+  version: 7.0.3
+  resolution: "@semantic-release/exec@npm:7.0.3"
+  dependencies:
+    "@semantic-release/error": "npm:^4.0.0"
+    aggregate-error: "npm:^3.0.0"
+    debug: "npm:^4.0.0"
+    execa: "npm:^9.0.0"
+    lodash-es: "npm:^4.17.21"
+    parse-json: "npm:^8.0.0"
+  peerDependencies:
+    semantic-release: ">=24.1.0"
+  checksum: 10/401d800d0f63fdd4acbeb3066a28ecfcde5b23b2dc6586ce192dc0a210d549320dc9e69cd16fe78a8a1a6d084129bf460eec35dc4a5266f951050eace28b0a58
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Summary

We were missing @semantic-release/exec and using it in our release config.